### PR TITLE
Improve install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,61 @@
 # arktypes
 
-The arktypes package contains LCM types for communication between Noah Embodied AI projects.
+**See the [ark_framework documentation](https://github.com/Robotics-Ark/ark_framework) for full setup instructions.**
 
-# Install
+The `arktypes` package provides LCM message definitions used by Robotics Ark projects.
 
-1. Ensure your conda environment is activated and ensure you have installed LCM.
-2. Change directory: `cd /path/to/noah_embodied_ai/arktypes`
-3. Build arktypes: `make`
+## Installation
 
-Uninstall: `make clean`
+The following examples show how to create a workspace, set up a conda environment and install the framework together with `arktypes`.
+
+### Linux
+```bash
+# create a workspace and enter it
+mkdir Ark
+cd Ark
+
+# create and activate the environment
+conda create -n ark_env python=3.10
+conda activate ark_env
+
+# clone and install the framework
+git clone https://github.com/Robotics-Ark/ark_framework.git
+cd ark_framework
+pip install -e .
+cd ..
+
+# clone and install ark_types
+git clone https://github.com/Robotics-Ark/ark_types.git
+cd ark_types
+pip install -e .
+```
+
+### macOS
+```bash
+# create a workspace and enter it
+mkdir Ark
+cd Ark
+
+# create and activate the environment
+conda create -n ark_env python=3.11
+conda activate ark_env
+
+# clone and install the framework
+git clone https://github.com/Robotics-Ark/ark_framework.git
+cd ark_framework
+pip install -e .
+
+# pybullet must be installed via conda on macOS
+conda install -c conda-forge pybullet
+cd ..
+
+# clone and install ark_types
+git clone https://github.com/Robotics-Ark/ark_types.git
+cd ark_types
+pip install -e .
+```
+
+After installation, verify the command-line tool is available:
+```bash
+ark --help
+```


### PR DESCRIPTION
## Summary
- update README with instructions on creating the `Ark` workspace
- note that full setup is in `ark_framework` documentation
- show how to install `ark_framework` and `ark_types` for Linux and macOS
- document `ark --help` for verification

## Testing
- `pip install -e .` *(fails: Could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68617d18a1a483218261547a3ad732ae