### PR TITLE
Added Gripper Control Variable to LCM Message of Task Space Control

### DIFF
--- a/ark_type_defs/robot_t.lcm
+++ b/ark_type_defs/robot_t.lcm
@@ -26,6 +26,7 @@ struct task_space_command_t {
     string name;
     position_t position;
     quaternion_t quaternion;
+    float gripper;
 }
 
 struct joint_state_t {

--- a/arktypes/utils/pack.py
+++ b/arktypes/utils/pack.py
@@ -773,7 +773,7 @@ def imu(orientation: np.ndarray, gyro: np.ndarray, accel: np.ndarray) -> imu_t:
     msg.accel = accel
     return msg
 
-def task_space_command(name: str, position_values: np.ndarray, quaternion_values: np.ndarray) -> task_space_command_t:
+def task_space_command(name: str, position_values: np.ndarray, quaternion_values: np.ndarray, gripper_values: float) -> task_space_command_t:
     """!
     Packs task space command data into a task_space_command_t message.
 
@@ -795,4 +795,5 @@ def task_space_command(name: str, position_values: np.ndarray, quaternion_values
     msg.name = name
     msg.position = position(x=position_list[0], y=position_list[1], z=position_list[2])
     msg.quaternion = quaternion(x=quaternion_list[0], y=quaternion_list[1], z=quaternion_list[2], w=quaternion_list[3])
+    msg.gripper = gripper_values  # Assuming gripper is a float value
     return msg

--- a/arktypes/utils/unpack.py
+++ b/arktypes/utils/unpack.py
@@ -637,7 +637,7 @@ def imu(msg: imu_t) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     accel = np.array(msg.accel)
     return orientation, gyro, accel
 
-def task_space_command(msg: task_space_command_t) -> Tuple[str, np.ndarray, np.ndarray]:
+def task_space_command(msg: task_space_command_t) -> Tuple[str, np.ndarray, np.ndarray, float]:
     """!
     Unpack a task_space_command_t message into its components.
 
@@ -650,4 +650,5 @@ def task_space_command(msg: task_space_command_t) -> Tuple[str, np.ndarray, np.n
     name = msg.name
     position_arr = position(msg.position)
     quaternion_arr = quaternion(msg.quaternion)
-    return name, position_arr, quaternion_arr
+    gripper_val = msg.gripper  # Assuming gripper is a float value
+    return name, position_arr, quaternion_arr, gripper_val


### PR DESCRIPTION
based on issue raised at: https://github.com/Robotics-Ark/ark_franka/issues/5

this is a temporary patch. 